### PR TITLE
Fix a couple issues I ran in to while building

### DIFF
--- a/R/r-minimal/Singularity.3.5.1
+++ b/R/r-minimal/Singularity.3.5.1
@@ -18,6 +18,7 @@ From: ubuntu:bionic
   exec R "--no-save --quiet --no-restore --no-environ $@"
 
 %post
+  export DEBIAN_FRONTEND=noninteractive
   export APT_OPTS="-y -o DPkg::Options::=--force-confdef"
   export VERSION="3.5.1"
   export MAKE="make -j 17"

--- a/R/r-minimal/Singularity.3.5.1
+++ b/R/r-minimal/Singularity.3.5.1
@@ -17,19 +17,18 @@ From: ubuntu:bionic
 %runscript
   exec R "--no-save --quiet --no-restore --no-environ $@"
 
-
-
 %post
+  export APT_OPTS="-y -o DPkg::Options::=--force-confdef"
   export VERSION="3.5.1"
   export MAKE="make -j 17"
   apt-get update
-  apt-get install -y locales
+  apt-get install $APT_OPTS locales
   echo "LC_ALL=en_US.UTF-8" >> /etc/environment
   echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
   echo "LANG=en_US.UTF-8" > /etc/locale.conf
   locale-gen en_US.UTF-8
   
-  apt-get install -y wget libopenblas-dev build-essential gfortran libreadline-dev libbz2-dev zlib1g-dev libpng-dev libjpeg-dev liblzma-dev libpcre3-dev libcurl4-openssl-dev libcairo2-dev
+  apt-get install $APT_OPTS wget libopenblas-dev build-essential gfortran libreadline-dev libbz2-dev zlib1g-dev libpng-dev libjpeg-dev liblzma-dev libpcre3-dev libcurl4-openssl-dev libcairo2-dev
   
   cd /tmp
   wget https://cran.r-project.org/src/base/R-3/R-${VERSION}.tar.gz
@@ -37,8 +36,7 @@ From: ubuntu:bionic
   cd R-${VERSION}
   ./configure --with-cairo=yes --with-x=no --enable-R-shlib=yes --enable-memory-profiling=no --with-blas="-lopenblas" --with-lapack
   make && make install
-  
   echo "options(bitmapType='cairo')" >> /usr/local/lib/R/etc/Rprofile.site
-  rm -rf /tmp/*
+  rm -rf /tmp/R-*
   apt-get autoclean
 


### PR DESCRIPTION
1. Set all of the non-interactive options for apt

2. Change the rm in tmp such that it does not remove all of /tmp
Since /tmp is shared with the host, deleteing all of /tmp can
lead to instability in the building OS.